### PR TITLE
bug fix: remove unuseful container after warden restart

### DIFF
--- a/warden/lib/warden/server.rb
+++ b/warden/lib/warden/server.rb
@@ -236,6 +236,7 @@ module Warden
 
         begin
           c = container_klass.from_snapshot(path)
+          c.setup_grace_timer
 
           logger.info("Recovered container at: #{path}", :resources => c.resources)
 


### PR DESCRIPTION
merge
